### PR TITLE
Install php-ast extension in github action, as requred for Phan

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install PHP AST extension
+      run:  sudo apt-get install -y php-ast
+
     - name: Validate composer.json and composer.lock
       run: composer validate
 
@@ -30,5 +33,4 @@ jobs:
       run: composer update --prefer-dist --no-progress --no-suggest
 
     - name: Run test suite
-      # Test suite is currently failing. @todo remove `|| true` when it passes.
-      run: make test || true
+      run: make test

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "ext-json": "*"
     },
     "require-dev": {
+        "ext-ast": "*",
         "phpstan/phpstan": "^0.12.2",
         "phan/phan": "^2.6",
         "vimeo/psalm": "^3.9",

--- a/tests/PhalyfusionTest.php
+++ b/tests/PhalyfusionTest.php
@@ -10,18 +10,20 @@ class PhalyfusionTest extends TestCase
         $runCommand = '../phalyfusion analyse -c configuration/phalyfusion_test.neon sampleCodebase/sampleNoErrors.php --no-ansi';
         $process = Process::fromShellCommandline($runCommand, __DIR__);
         $process->run();
+        $this->assertSuccessful($process);
         $this->assertStringEqualsFile(__DIR__ . '/expectedOutputs/noErrorsText.txt',$process->getOutput());
 
         $runCommand = '../phalyfusion analyse -c configuration/phalyfusion_test.neon sampleCodebase/sampleNoErrors.php -f json';
         $process = Process::fromShellCommandline($runCommand, __DIR__);
         $process->run();
+        $this->assertSuccessful($process);
         $this->assertStringEqualsFile(__DIR__ . '/expectedOutputs/noErrorsJson.txt',$process->getOutput());
 
         $runCommand = '../phalyfusion analyse -c configuration/phalyfusion_test.neon sampleCodebase/sampleNoErrors.php -f checkstyle';
         $process = Process::fromShellCommandline($runCommand, __DIR__);
         $process->run();
+        $this->assertSuccessful($process);
         $this->assertStringEqualsFile(__DIR__ . '/expectedOutputs/noErrorsCheckstyle.txt',$process->getOutput());
-
     }
 
     public function testPhalyfusion()
@@ -29,18 +31,30 @@ class PhalyfusionTest extends TestCase
         $runCommand = '../phalyfusion analyse -c configuration/phalyfusion_test.neon --no-ansi';
         $process = Process::fromShellCommandline($runCommand, __DIR__);
         $process->run();
+        $this->assertSuccessful($process);
         $this->assertStringEqualsFile(__DIR__ . '/expectedOutputs/errorsText.txt',$process->getOutput());
 
         $runCommand = '../phalyfusion analyse -c configuration/phalyfusion_test.neon -f json';
         $process = Process::fromShellCommandline($runCommand, __DIR__);
         $process->run();
+        $this->assertSuccessful($process);
         $this->assertStringEqualsFile(__DIR__ . '/expectedOutputs/errorsJson.txt',$process->getOutput());
 
         $runCommand = '../phalyfusion analyse -c configuration/phalyfusion_test.neon -f checkstyle';
         $process = Process::fromShellCommandline($runCommand, __DIR__);
         $process->run();
+        $this->assertSuccessful($process);
         $this->assertStringEqualsFile(__DIR__ . '/expectedOutputs/errorsCheckstyle.txt',$process->getOutput());
 
+    }
+
+    private function assertSuccessful(Process $process): void
+    {
+        $this->assertSame(
+            0,
+            $process->getExitCode(),
+            "\"{$process->getCommandLine()}\" returned code {$process->getExitCode()}. Error output: \n\n{$process->getErrorOutput()}"
+        );
     }
 
 }

--- a/tests/PhalyfusionTest.php
+++ b/tests/PhalyfusionTest.php
@@ -5,20 +5,26 @@ use PHPUnit\Framework\TestCase;
 
 class PhalyfusionTest extends TestCase
 {
-    public function testPhalyfusionNoErrors()
+    public function testPhalyfusionNoErrorsNoAnsi(): void
     {
         $runCommand = '../phalyfusion analyse -c configuration/phalyfusion_test.neon sampleCodebase/sampleNoErrors.php --no-ansi';
         $process = Process::fromShellCommandline($runCommand, __DIR__);
         $process->run();
         $this->assertSuccessful($process);
-        $this->assertStringEqualsFile(__DIR__ . '/expectedOutputs/noErrorsText.txt',$process->getOutput());
+        $this->assertStringEqualsFile(__DIR__ . '/expectedOutputs/noErrorsText.txt', $process->getOutput());
+    }
 
+    public function testPhalyfusionNoErrorsJsonFormat(): void
+    {
         $runCommand = '../phalyfusion analyse -c configuration/phalyfusion_test.neon sampleCodebase/sampleNoErrors.php -f json';
         $process = Process::fromShellCommandline($runCommand, __DIR__);
         $process->run();
         $this->assertSuccessful($process);
         $this->assertStringEqualsFile(__DIR__ . '/expectedOutputs/noErrorsJson.txt',$process->getOutput());
+    }
 
+    public function testPhalyfusionNoErrorsCheckstyleFormat(): void
+    {
         $runCommand = '../phalyfusion analyse -c configuration/phalyfusion_test.neon sampleCodebase/sampleNoErrors.php -f checkstyle';
         $process = Process::fromShellCommandline($runCommand, __DIR__);
         $process->run();
@@ -26,20 +32,26 @@ class PhalyfusionTest extends TestCase
         $this->assertStringEqualsFile(__DIR__ . '/expectedOutputs/noErrorsCheckstyle.txt',$process->getOutput());
     }
 
-    public function testPhalyfusion()
+    public function testPhalyfusionNoAnsi(): void
     {
         $runCommand = '../phalyfusion analyse -c configuration/phalyfusion_test.neon --no-ansi';
         $process = Process::fromShellCommandline($runCommand, __DIR__);
         $process->run();
         $this->assertSuccessful($process);
-        $this->assertStringEqualsFile(__DIR__ . '/expectedOutputs/errorsText.txt',$process->getOutput());
+        $this->assertStringEqualsFile(__DIR__ . '/expectedOutputs/errorsText.txt', $process->getOutput());
+    }
 
+    public function testPhalyfusionJsonFormat(): void
+    {
         $runCommand = '../phalyfusion analyse -c configuration/phalyfusion_test.neon -f json';
         $process = Process::fromShellCommandline($runCommand, __DIR__);
         $process->run();
         $this->assertSuccessful($process);
         $this->assertStringEqualsFile(__DIR__ . '/expectedOutputs/errorsJson.txt',$process->getOutput());
+    }
 
+    public function testPhalyfusionCheckStyleFormat(): void
+    {
         $runCommand = '../phalyfusion analyse -c configuration/phalyfusion_test.neon -f checkstyle';
         $process = Process::fromShellCommandline($runCommand, __DIR__);
         $process->run();
@@ -56,5 +68,4 @@ class PhalyfusionTest extends TestCase
             "\"{$process->getCommandLine()}\" returned code {$process->getExitCode()}. Error output: \n\n{$process->getErrorOutput()}"
         );
     }
-
 }


### PR DESCRIPTION
Tests were failing on github actions (and my local) because the php-ast extension wasn't installed. This PR installs it in the action, and stops allowing the test suite to fail without failing the action.

It wasn't immediately obvious what was wrong because when the test failed it only displayed the standard output. I've made it output the error output in case of an unexpected error in future.